### PR TITLE
Specify provider to 'rpm'

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,8 @@ class tcpdp::install(
 ) {
 
   package { 'tcpdp':
-    source => "https://github.com/k1LoW/tcpdp/releases/download/v${version}/tcpdp-${version}-1.el7.x86_64.rpm",
+    provider => rpm,
+    source   => "https://github.com/k1LoW/tcpdp/releases/download/v${version}/tcpdp-${version}-1.el7.x86_64.rpm",
   }
 
 }


### PR DESCRIPTION
~As far as I searched, in puppet 4 and earlier, if only source was specified in the package resource, yum provider was selected and source was not used.~


```
Notice: /Stage[main]/Tcpdp::Service/Service[tcpdp-enp0s8]/ensure: ensure changed 'stopped' to 'running'
Error: Execution of '/bin/yum -d 0 -e 0 -y install tcpdp' returned 1: Error: Nothing to do
Error: /Stage[main]/Tcpdp::Install/Package[tcpdp]/ensure: change from purged to present failed: Execution of '/bin/yum -d 0 -e 0 -y install tcpdp' returned 1: Error: Nothing to do
```