### PR TITLE
For older version

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,8 @@ class tcpdp::install(
 ) {
 
   package { 'tcpdp':
-    source => "https://github.com/k1LoW/tcpdp/releases/download/v${version}/tcpdp-${version}-1.el7.x86_64.rpm",
+    provider => rpm,
+    source   => "https://github.com/k1LoW/tcpdp/releases/download/v${version}/tcpdp-${version}-1.el7.x86_64.rpm",
   }
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,9 +2,12 @@ class tcpdp::install(
   $version = $tcpdp::version,
 ) {
 
+  package { 'libpcap': }
+
   package { 'tcpdp':
     provider => rpm,
     source   => "https://github.com/k1LoW/tcpdp/releases/download/v${version}/tcpdp-${version}-1.el7.x86_64.rpm",
+    require  => Package['libpcap'],
   }
 
 }


### PR DESCRIPTION
https://github.com/tnmt/puppet-tcpdp/issues/3

2 changes.

* Specify `rpm` provider to avoid [old Puppet bugs](https://tickets.puppetlabs.com/browse/PUP-3323).
* Add Package resource to install libpcap that is needed by tcpdp. (It was implicitly installed with yum
.)