### PR TITLE
Update requirement 'puppet-archive

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,7 +3,7 @@
 #
 # tcpdp
 class tcpdp(
-  String $version                             = '0.16.1',
+  String $version                             = '0.21.2',
   Array[String] $interfaces                   = undef,
   Boolean $manage_interface_toml              = true,
   String $dumper                              = 'mysql',

--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppet-archive",
-      "version_requirement": ">= 2.0.0 < 4.0.0"
+      "version_requirement": ">= 2.0.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
A dependency conflict has occurred. puppet-archive has 4.5.0, so update the requirements.

```
[Librarian]     Checking puppet-tcpdp/0.1.1 <https://github.com/tnmt/puppet-tcpdp#master>
[Librarian]       Resolved puppet-tcpdp (>= 0) <https://github.com/tnmt/puppet-tcpdp#master> at puppet-tcpdp/0.1.1 <https://github.com/tnmt/puppet-tcpdp#master>
[Librarian]   Resolved puppet-tcpdp (>= 0) <https://github.com/tnmt/puppet-tcpdp#master>
[Librarian] Conflict between puppet-archive (>= 2.0.0, < 4.0.0) <https://forgeapi.puppetlabs.com> and puppet-archive/4.5.0 <https://forgeapi.puppetlabs.com>
Could not resolve the dependencies.
```